### PR TITLE
Feature/add read only datalake

### DIFF
--- a/.github/deploy/cloud_and_account/azure_cloud_resources.tf
+++ b/.github/deploy/cloud_and_account/azure_cloud_resources.tf
@@ -2,8 +2,8 @@
 
 # Provision resource group -----------------------------------------------------
 resource "azurerm_resource_group" "rg" {
-  name      = local.resource_group_name
-  location  = module.global_variables.location
+  name     = local.resource_group_name
+  location = module.global_variables.location
   tags = {
     creator = module.global_variables.creator_tag
     system  = module.global_variables.system_tag
@@ -18,8 +18,7 @@ resource "azurerm_storage_account" "storage_account" {
   location                 = azurerm_resource_group.rg.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
-  is_hns_enabled = true
-
+  is_hns_enabled           = true
   tags = {
     creator = module.global_variables.creator_tag
     system  = module.global_variables.system_tag
@@ -36,7 +35,7 @@ resource "azurerm_key_vault" "key_vault" {
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
   soft_delete_retention_days = 7
-  depends_on = [azurerm_resource_group.rg]
+  depends_on                 = [azurerm_resource_group.rg]
 }
 
 # Provision access connector and setting its role ------------------------------
@@ -53,21 +52,18 @@ resource "azurerm_databricks_access_connector" "ext_access_connector" {
 resource "azurerm_role_assignment" "ext_storage_role" {
   scope                = azurerm_storage_account.storage_account.id
   role_definition_name = "Storage Blob Data Contributor"
-  principal_id         = join(
-    "",
-    [azurerm_databricks_access_connector.ext_access_connector.identity[0].principal_id]
-  )
+  principal_id         = azurerm_databricks_access_connector.ext_access_connector.identity[0].principal_id
   depends_on = [
     azurerm_databricks_access_connector.ext_access_connector,
     azurerm_storage_account.storage_account
-    ]
+  ]
 }
 
 # Provision containers ---------------------------------------------------------
 
 ## Landing container
 resource "azurerm_storage_container" "landing" {
-  name  = var.az_landing_storage_container
+  name                  = var.az_landing_storage_container
   storage_account_name  = azurerm_storage_account.storage_account.name
   container_access_type = "private"
   depends_on            = [azurerm_storage_account.storage_account]
@@ -75,7 +71,7 @@ resource "azurerm_storage_container" "landing" {
 
 ## Data container
 resource "azurerm_storage_container" "data" {
-  name  = module.global_variables.az_data_container
+  name                  = module.global_variables.az_data_container
   storage_account_name  = azurerm_storage_account.storage_account.name
   container_access_type = "private"
   depends_on            = [azurerm_storage_account.storage_account]
@@ -91,14 +87,14 @@ resource "azurerm_storage_container" "infrastructure" {
 
 # Provision databricks service ------------------------------------------------
 resource "azurerm_databricks_workspace" "db_workspace" {
-  name                        = local.resource_name
-  resource_group_name         = azurerm_resource_group.rg.name
-  location                    = azurerm_resource_group.rg.location
-  sku                         = "premium"
+  name                = local.resource_name
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  sku                 = "premium"
   tags = {
     creator = module.global_variables.creator_tag
     system  = module.global_variables.system_tag
     service = module.global_variables.service_tag
   }
-  depends_on                  = [azurerm_resource_group.rg]
+  depends_on = [azurerm_resource_group.rg]
 }

--- a/.github/deploy/cloud_and_account/azure_cloud_resources.tf
+++ b/.github/deploy/cloud_and_account/azure_cloud_resources.tf
@@ -63,7 +63,7 @@ resource "azurerm_role_assignment" "ext_storage_role" {
 
 ## Landing container
 resource "azurerm_storage_container" "landing" {
-  name                  = var.az_landing_storage_container
+  name                  = module.global_variables.az_landing_container
   storage_account_name  = azurerm_storage_account.storage_account.name
   container_access_type = "private"
   depends_on            = [azurerm_storage_account.storage_account]

--- a/.github/deploy/cloud_and_account/azure_cloud_resources.tf
+++ b/.github/deploy/cloud_and_account/azure_cloud_resources.tf
@@ -4,11 +4,7 @@
 resource "azurerm_resource_group" "rg" {
   name     = local.resource_group_name
   location = module.global_variables.location
-  tags = {
-    creator = module.global_variables.creator_tag
-    system  = module.global_variables.system_tag
-    service = module.global_variables.service_tag
-  }
+  tags     = module.global_variables.tags
 }
 
 # Provision storage account -----------------------------------------------------
@@ -19,12 +15,8 @@ resource "azurerm_storage_account" "storage_account" {
   account_tier             = "Standard"
   account_replication_type = "LRS"
   is_hns_enabled           = true
-  tags = {
-    creator = module.global_variables.creator_tag
-    system  = module.global_variables.system_tag
-    service = module.global_variables.service_tag
-  }
-  depends_on = [azurerm_resource_group.rg]
+  tags                     = module.global_variables.tags
+  depends_on               = [azurerm_resource_group.rg]
 }
 
 # Provision keyvault -----------------------------------------------------------
@@ -91,10 +83,6 @@ resource "azurerm_databricks_workspace" "db_workspace" {
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   sku                 = "premium"
-  tags = {
-    creator = module.global_variables.creator_tag
-    system  = module.global_variables.system_tag
-    service = module.global_variables.service_tag
-  }
-  depends_on = [azurerm_resource_group.rg]
+  tags                = module.global_variables.tags
+  depends_on          = [azurerm_resource_group.rg]
 }

--- a/.github/deploy/cloud_and_account/azure_keyvault_secrets.tf
+++ b/.github/deploy/cloud_and_account/azure_keyvault_secrets.tf
@@ -3,9 +3,9 @@
 # Create a secret for the azure subscription tenant id -------------------------
 resource "azurerm_key_vault_secret" "azure_tenant_id" {
   name         = module.global_variables.az_kv_tenant_id
-  value        = "${data.azurerm_client_config.current.tenant_id}"
+  value        = data.azurerm_client_config.current.tenant_id
   key_vault_id = azurerm_key_vault.key_vault.id
-  depends_on   = [
+  depends_on = [
     azurerm_key_vault.key_vault,
     azurerm_key_vault_access_policy.spn_access
   ]
@@ -16,7 +16,7 @@ resource "azurerm_key_vault_secret" "db_ws_url" {
   name         = module.global_variables.az_kv_db_ws_url
   value        = "https://${azurerm_databricks_workspace.db_workspace.workspace_url}/"
   key_vault_id = azurerm_key_vault.key_vault.id
-  depends_on   = [
+  depends_on = [
     azurerm_key_vault.key_vault,
     azurerm_databricks_workspace.db_workspace,
     azurerm_key_vault_access_policy.spn_access
@@ -26,9 +26,9 @@ resource "azurerm_key_vault_secret" "db_ws_url" {
 # Create secrets for the created metasore admin spn credentials ----------------
 resource "azurerm_key_vault_secret" "db_meta_admin_spn_app_id" {
   name         = var.az_kv_db_metastore_spn_app_id
-  value        = "${data.azuread_service_principal.db_meta_spn.client_id}"
+  value        = data.azuread_service_principal.db_meta_spn.client_id
   key_vault_id = azurerm_key_vault.key_vault.id
-  depends_on   = [
+  depends_on = [
     azurerm_key_vault.key_vault,
     data.azuread_service_principal.db_meta_spn,
     azurerm_key_vault_access_policy.spn_access
@@ -37,9 +37,9 @@ resource "azurerm_key_vault_secret" "db_meta_admin_spn_app_id" {
 
 resource "azurerm_key_vault_secret" "db_meta_admin_spn_app_password" {
   name         = var.az_kv_db_metastore_spn_app_password
-  value        = "${azuread_service_principal_password.db_meta_spn_password.value}"
+  value        = azuread_service_principal_password.db_meta_spn_password.value
   key_vault_id = azurerm_key_vault.key_vault.id
-  depends_on   = [
+  depends_on = [
     azurerm_key_vault.key_vault,
     azuread_service_principal_password.db_meta_spn_password,
     azurerm_key_vault_access_policy.spn_access
@@ -49,9 +49,9 @@ resource "azurerm_key_vault_secret" "db_meta_admin_spn_app_password" {
 # Create secrets for the created workspace admin spn credentials ---------------
 resource "azurerm_key_vault_secret" "db_ws_admin_spn_app_id" {
   name         = module.global_variables.az_kv_db_workspace_spn_app_id
-  value        = "${azuread_service_principal.db_ws_spn.client_id}"
+  value        = azuread_service_principal.db_ws_spn.client_id
   key_vault_id = azurerm_key_vault.key_vault.id
-  depends_on   = [
+  depends_on = [
     azurerm_key_vault.key_vault,
     azuread_service_principal.db_ws_spn,
     azurerm_key_vault_access_policy.spn_access
@@ -60,9 +60,9 @@ resource "azurerm_key_vault_secret" "db_ws_admin_spn_app_id" {
 
 resource "azurerm_key_vault_secret" "db_ws_admin_spn_app_password" {
   name         = module.global_variables.az_kv_db_workspace_spn_app_password
-  value        = "${azuread_service_principal_password.db_ws_spn_password.value}"
+  value        = azuread_service_principal_password.db_ws_spn_password.value
   key_vault_id = azurerm_key_vault.key_vault.id
-  depends_on   = [
+  depends_on = [
     azurerm_key_vault.key_vault,
     azuread_service_principal_password.db_ws_spn_password,
     azurerm_key_vault_access_policy.spn_access

--- a/.github/deploy/cloud_and_account/cloud_and_account_data.tf
+++ b/.github/deploy/cloud_and_account/cloud_and_account_data.tf
@@ -17,8 +17,8 @@ data "azuread_service_principal" "db_meta_spn" {
 data "azuread_client_config" "current" {}
 
 data "databricks_metastore" "db_metastore" {
-  provider     = databricks.account
-  name         = module.global_variables.db_metastore_name
+  provider = databricks.account
+  name     = module.global_variables.db_metastore_name
 }
 
 data "databricks_group" "db_metastore_admin_group" {

--- a/.github/deploy/cloud_and_account/databricks_access_control.tf
+++ b/.github/deploy/cloud_and_account/databricks_access_control.tf
@@ -161,11 +161,11 @@ resource "databricks_grants" "infrastructure" {
 ## Create external location and grant privilages for landing data storage 
 resource "databricks_external_location" "landing" {
   provider = databricks.workspace
-  name     = "${var.environment}-${var.az_landing_storage_container}"
+  name     = "${var.environment}-${module.global_variables.az_landing_container}"
   url = join(
     "",
     [
-      "abfss://${var.az_landing_storage_container}",
+      "abfss://${module.global_variables.az_landing_container}",
       "@${azurerm_storage_account.storage_account.name}.dfs.core.windows.net/"
     ]
   )

--- a/.github/deploy/cloud_and_account/databricks_access_control.tf
+++ b/.github/deploy/cloud_and_account/databricks_access_control.tf
@@ -201,6 +201,45 @@ resource "databricks_grants" "landing" {
   ]
 }
 
+## Create external location and grant privilages for imgestion data storage
+resource "databricks_external_location" "ingestion" {
+  provider        = databricks.workspace
+  name            = "${var.environment}-${module.global_variables.az_ingestion_container}"
+  credential_name = databricks_storage_credential.ex_storage_cred.id
+  comment         = "Databricks external location for ingestion data"
+  read_only       = true
+  skip_validation = true # The validation step is not working for read-only external locations. The external location works fine after creation.
+  url             = "abfss://${module.global_variables.az_ingestion_container}@${azurerm_storage_account.storage_account_ingestion.name}.dfs.core.windows.net/"
+  depends_on = [
+    databricks_grants.ex_creds,
+    time_sleep.wait_for_ex_storage_cred_grants
+  ]
+}
+
+resource "time_sleep" "wait_for_ingestion_ext_location" {
+  create_duration = "5s"
+  depends_on = [
+    databricks_external_location.ingestion
+  ]
+}
+
+resource "databricks_grants" "ingestion" {
+  provider          = databricks.workspace
+  external_location = databricks_external_location.ingestion.id
+  grant {
+    principal  = databricks_group.db_ws_admin_group.display_name
+    privileges = ["READ_FILES"]
+  }
+  grant {
+    principal  = data.databricks_group.db_metastore_admin_group.display_name
+    privileges = ["READ_FILES"]
+  }
+  depends_on = [
+    databricks_external_location.landing,
+    time_sleep.wait_for_ingestion_ext_location
+  ]
+}
+
 # Access control for catalogs -------------------------------------------------------------------------
 
 ## Grant privilages for the infrastructure catalog

--- a/.github/deploy/cloud_and_account/databricks_account.tf
+++ b/.github/deploy/cloud_and_account/databricks_account.tf
@@ -11,15 +11,15 @@ resource "databricks_service_principal" "db_ws_spn" {
   provider       = databricks.account
   application_id = azuread_service_principal.db_ws_spn.client_id
   display_name   = local.db_workspace_spn_name
-  depends_on     = [
+  depends_on = [
     azuread_service_principal.db_ws_spn
   ]
 }
 
 resource "databricks_group_member" "ws_admin_member" {
-  provider   = databricks.account
-  group_id   = databricks_group.db_ws_admin_group.id
-  member_id  = databricks_service_principal.db_ws_spn.id
+  provider  = databricks.account
+  group_id  = databricks_group.db_ws_admin_group.id
+  member_id = databricks_service_principal.db_ws_spn.id
   depends_on = [
     databricks_group.db_ws_admin_group,
     databricks_service_principal.db_ws_spn
@@ -28,9 +28,9 @@ resource "databricks_group_member" "ws_admin_member" {
 
 ## For spetlr test purposes, we need to add cicd spn to the workspace admin group
 resource "databricks_group_member" "ws_admin_member_cicd" {
-  provider   = databricks.account
-  group_id   = databricks_group.db_ws_admin_group.id
-  member_id  = data.databricks_service_principal.cicd_pipeline_spn.id
+  provider  = databricks.account
+  group_id  = databricks_group.db_ws_admin_group.id
+  member_id = data.databricks_service_principal.cicd_pipeline_spn.id
   depends_on = [
     databricks_group.db_ws_admin_group,
     databricks_service_principal.db_ws_spn
@@ -39,9 +39,9 @@ resource "databricks_group_member" "ws_admin_member_cicd" {
 
 ## We want the workspace admin spn also the role of metastore admin, so adding it to meta admin group
 resource "databricks_group_member" "metastore_admin_member_ws" {
-  provider   = databricks.account
-  group_id   = data.databricks_group.db_metastore_admin_group.id
-  member_id  = databricks_service_principal.db_ws_spn.id
+  provider  = databricks.account
+  group_id  = data.databricks_group.db_metastore_admin_group.id
+  member_id = databricks_service_principal.db_ws_spn.id
   depends_on = [
     data.databricks_group.db_metastore_admin_group,
     databricks_service_principal.db_ws_spn

--- a/.github/deploy/cloud_and_account/databricks_catalog.tf
+++ b/.github/deploy/cloud_and_account/databricks_catalog.tf
@@ -8,8 +8,8 @@ resource "databricks_catalog" "db_infrastructure_catalog" {
   comment        = "Catalog to encapsulate all data schema under this workspace"
   isolation_mode = "ISOLATED"
   storage_root   = databricks_external_location.infrastructure.url
-  owner = data.databricks_group.db_metastore_admin_group.display_name
-  depends_on     = [
+  owner          = data.databricks_group.db_metastore_admin_group.display_name
+  depends_on = [
     databricks_external_location.infrastructure,
     data.databricks_group.db_metastore_admin_group
   ]
@@ -22,13 +22,13 @@ resource "databricks_schema" "db_infrastructure_schema" {
   catalog_name = databricks_catalog.db_infrastructure_catalog.name
   name         = local.infrastructure_schema
   comment      = "this schema is for infrastructure volume"
-  properties   = {
+  properties = {
     kind = "various"
   }
-  owner        = data.databricks_group.db_metastore_admin_group.display_name
-  storage_root = "${databricks_external_location.infrastructure.url}${local.infrastructure_schema}/"
+  owner         = data.databricks_group.db_metastore_admin_group.display_name
+  storage_root  = "${databricks_external_location.infrastructure.url}${local.infrastructure_schema}/"
   force_destroy = true
-  depends_on   = [
+  depends_on = [
     databricks_catalog.db_infrastructure_catalog,
     databricks_grants.infrastructure_catalog
   ]
@@ -45,7 +45,7 @@ resource "databricks_volume" "db_infrastructure_libraries_volume" {
   storage_location = "${databricks_external_location.infrastructure.url}${module.global_variables.az_infrastructure_libraries_folder}/"
   comment          = "External volume to store infrastructure library files"
   owner            = data.databricks_group.db_metastore_admin_group.display_name
-  depends_on       = [
+  depends_on = [
     databricks_schema.db_infrastructure_schema,
     # databricks_grants.infrastructure_libraries_volume
   ]

--- a/.github/deploy/cloud_and_account/providers.tf
+++ b/.github/deploy/cloud_and_account/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    azurerm   = {
+    azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.7.0"
     }
@@ -9,10 +9,10 @@ terraform {
     }
   }
   backend "azurerm" {
-      resource_group_name  = "Terraform-State-Stoarge"
-      storage_account_name = "spetlrlhv2tfstate"
-      container_name       = "tfstate"
-      key                  = "terraform_cloud_and_account.tfstate"
+    resource_group_name  = "Terraform-State-Stoarge"
+    storage_account_name = "spetlrlhv2tfstate"
+    container_name       = "tfstate"
+    key                  = "terraform_cloud_and_account.tfstate"
   }
 }
 

--- a/.github/deploy/cloud_and_account/variables.tf
+++ b/.github/deploy/cloud_and_account/variables.tf
@@ -13,12 +13,6 @@ variable "db_workspace_spn_name" {
   description = "SPN to be added as a Databricks workspace Admin"
 }
 
-variable "az_landing_storage_container" {
-  type        = string
-  default     = "landing"
-  description = "Containers in the storage account as the external location for corresponding data layers"
-}
-
 variable "az_kv_db_metastore_spn_app_id" {
   type        = string
   default     = "Databricks--Metastore--SPN-ID"

--- a/.github/deploy/cloud_and_account/variables.tf
+++ b/.github/deploy/cloud_and_account/variables.tf
@@ -42,6 +42,9 @@ locals {
   resource_group_name = "${module.global_variables.system_name}-${upper(var.environment)}-${module.global_variables.service_name}"
   resource_name       = "${module.global_variables.company_abbreviation}${module.global_variables.system_abbreviation}${var.environment}"
 
+  # Specific name for datalake used for ingestion with only read access
+  datalake_ingestion_resource_name = "${module.global_variables.company_abbreviation}${module.global_variables.system_abbreviation}ingestion${var.environment}"
+
   # Databricks groups
   db_workspace_admin_group_env = "${module.global_variables.db_workspace_admin_group}-${var.environment}"
   db_table_user_group          = "${var.db_table_user_group}-${var.environment}"

--- a/.github/deploy/cloud_and_account/variables.tf
+++ b/.github/deploy/cloud_and_account/variables.tf
@@ -8,32 +8,32 @@ variable "environment" {
 }
 
 variable "db_workspace_spn_name" {
-  type = string
-  default = "SpetlrLhV2DbWs"
+  type        = string
+  default     = "SpetlrLhV2DbWs"
   description = "SPN to be added as a Databricks workspace Admin"
 }
 
 variable "az_landing_storage_container" {
-  type = string
-  default = "landing"
+  type        = string
+  default     = "landing"
   description = "Containers in the storage account as the external location for corresponding data layers"
 }
 
 variable "az_kv_db_metastore_spn_app_id" {
-  type = string
-  default = "Databricks--Metastore--SPN-ID"
+  type        = string
+  default     = "Databricks--Metastore--SPN-ID"
   description = "The Azure Keyvault secret for Application ID of the metastore admin SPN"
 }
 
 variable "az_kv_db_metastore_spn_app_password" {
-  type = string
-  default = "Databricks--Metastore--SPN-Password"
+  type        = string
+  default     = "Databricks--Metastore--SPN-Password"
   description = "The Azure Keyvault secret for Application password of the metastore admin SPN"
 }
 
 variable "db_table_user_group" {
-  type = string
-  default = "SpetlrLhV2-table-users"
+  type        = string
+  default     = "SpetlrLhV2-table-users"
   description = "A Databricks workspace group with table usage privilages"
 }
 
@@ -44,13 +44,13 @@ variable "db_account_id" {
 
 # Some of the variables need to be suffixed with the environment name or other unique identifier
 locals {
-  # Azure resources 
+  # Azure resources
   resource_group_name = "${module.global_variables.system_name}-${upper(var.environment)}-${module.global_variables.service_name}"
-  resource_name = "${module.global_variables.company_abbreviation}${module.global_variables.system_abbreviation}${var.environment}"
+  resource_name       = "${module.global_variables.company_abbreviation}${module.global_variables.system_abbreviation}${var.environment}"
 
   # Databricks groups
   db_workspace_admin_group_env = "${module.global_variables.db_workspace_admin_group}-${var.environment}"
-  db_table_user_group = "${var.db_table_user_group}-${var.environment}"
+  db_table_user_group          = "${var.db_table_user_group}-${var.environment}"
 
   # Databricks catalog and schema for infrastructure
   infrastructure_catalog = "${module.global_variables.az_infrastructure_container}_${var.environment}"

--- a/.github/deploy/global_variables/output.tf
+++ b/.github/deploy/global_variables/output.tf
@@ -1,82 +1,82 @@
 # Output for naming convention and global variables
-output company_abbreviation {
+output "company_abbreviation" {
   value = var.company_abbreviation
 }
 
-output system_abbreviation {
+output "system_abbreviation" {
   value = var.system_abbreviation
 }
 
-output system_name {
+output "system_name" {
   value = var.system_name
 }
 
-output service_name {
+output "service_name" {
   value = var.service_name
 }
 
-output location {
+output "location" {
   value = var.location
 }
 
-output service_tag {
+output "service_tag" {
   value = var.service_tag
 }
 
-output system_tag {
+output "system_tag" {
   value = var.system_tag
 }
 
-output creator_tag {
+output "creator_tag" {
   value = var.creator_tag
 }
 
 # Output for Azure variables
-output cicdSpnName {
+output "cicdSpnName" {
   value = var.cicdSpnName
 }
 
-output db_metastore_spn_name {
+output "db_metastore_spn_name" {
   value = var.db_metastore_spn_name
 }
 
-output az_kv_tenant_id {
+output "az_kv_tenant_id" {
   value = var.az_kv_tenant_id
 }
 
-output az_kv_db_ws_url {
+output "az_kv_db_ws_url" {
   value = var.az_kv_db_ws_url
 }
 
-output az_kv_db_workspace_spn_app_id {
+output "az_kv_db_workspace_spn_app_id" {
   value = var.az_kv_db_workspace_spn_app_id
 }
 
-output az_kv_db_workspace_spn_app_password {
+output "az_kv_db_workspace_spn_app_password" {
   value = var.az_kv_db_workspace_spn_app_password
 }
 
-output az_infrastructure_container {
+output "az_infrastructure_container" {
   value = var.az_infrastructure_container
 }
 
-output az_infrastructure_libraries_folder {
+output "az_infrastructure_libraries_folder" {
   value = var.az_infrastructure_libraries_folder
 }
 
-output az_data_container {
+output "az_data_container" {
   value = var.az_data_container
 }
 
 # Output for Databricks variables
-output db_metastore_name {
+output "db_metastore_name" {
   value = var.db_metastore_name
 }
 
-output db_metastore_admin_group {
+output "db_metastore_admin_group" {
   value = var.db_metastore_admin_group
 }
 
-output db_workspace_admin_group {
+output "db_workspace_admin_group" {
   value = var.db_workspace_admin_group
 }

--- a/.github/deploy/global_variables/output.tf
+++ b/.github/deploy/global_variables/output.tf
@@ -31,6 +31,10 @@ output "creator_tag" {
   value = var.creator_tag
 }
 
+output "tags" {
+  value = local.tags
+}
+
 # Output for Azure variables
 output "cicdSpnName" {
   value = var.cicdSpnName
@@ -62,6 +66,10 @@ output "az_infrastructure_container" {
 
 output "az_infrastructure_libraries_folder" {
   value = var.az_infrastructure_libraries_folder
+}
+
+output "az_ingestion_container" {
+  value = var.az_ingestion_container
 }
 
 output "az_landing_container" {

--- a/.github/deploy/global_variables/output.tf
+++ b/.github/deploy/global_variables/output.tf
@@ -64,6 +64,10 @@ output "az_infrastructure_libraries_folder" {
   value = var.az_infrastructure_libraries_folder
 }
 
+output "az_landing_container" {
+  value = var.az_landing_container
+}
+
 output "az_data_container" {
   value = var.az_data_container
 }

--- a/.github/deploy/global_variables/variables.tf
+++ b/.github/deploy/global_variables/variables.tf
@@ -47,6 +47,14 @@ variable "creator_tag" {
   description = "Use for tagging"
 }
 
+locals {
+  tags = {
+    creator = var.creator_tag
+    system  = var.system_tag
+    service = var.service_tag
+  }
+}
+
 # Azure variables
 variable "cicdSpnName" {
   type        = string
@@ -94,6 +102,12 @@ variable "az_infrastructure_libraries_folder" {
   type        = string
   default     = "libraries"
   description = "The name of a folder inside infrastructure container to store library files (like python wheels)"
+}
+
+variable "az_ingestion_container" {
+  type        = string
+  default     = "ingestion"
+  description = "Container in the external read-only storage"
 }
 
 variable "az_landing_container" {

--- a/.github/deploy/global_variables/variables.tf
+++ b/.github/deploy/global_variables/variables.tf
@@ -96,6 +96,12 @@ variable "az_infrastructure_libraries_folder" {
   description = "The name of a folder inside infrastructure container to store library files (like python wheels)"
 }
 
+variable "az_landing_container" {
+  type        = string
+  default     = "landing"
+  description = "Container in the storage account for raw data"
+}
+
 variable "az_data_container" {
   type        = string
   default     = "data"

--- a/.github/deploy/global_variables/variables.tf
+++ b/.github/deploy/global_variables/variables.tf
@@ -55,8 +55,8 @@ variable "cicdSpnName" {
 }
 
 variable "db_metastore_spn_name" {
-  type = string
-  default = "SpetlrLhV2DbMeta"
+  type        = string
+  default     = "SpetlrLhV2DbMeta"
   description = "SPN to be added as a Databricks Metastore Admin"
 }
 


### PR DESCRIPTION
Add ingestion datalake with read-only access from databricks to storage account.

The read-only flag for external locations is failing validating by mistake, because the external location is working fine after creating without validation.